### PR TITLE
full crud on categories and tags

### DIFF
--- a/rareapi/views/categories.py
+++ b/rareapi/views/categories.py
@@ -3,14 +3,14 @@ from rest_framework import serializers
 from rest_framework.response import Response
 from rareapi.models import Category
 
+
 class CategorySerializer(serializers.ModelSerializer):
     class Meta:
         model = Category
-        fields = ['id', 'label']
+        fields = ["id", "label"]
 
 
 class CategoryViewSet(viewsets.ViewSet):
-
     def list(self, request):
         categories = Category.objects.all()
         serializer = CategorySerializer(categories, many=True)
@@ -21,5 +21,51 @@ class CategoryViewSet(viewsets.ViewSet):
             category = Category.objects.get(pk=pk)
             serializer = CategorySerializer(category)
             return Response(serializer.data)
+        except Category.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+    def create(self, request):
+        # Get the data from the client's JSON payload
+        label = request.data.get("label")
+
+        # Create a comment database row first, so you have a
+        # primary key to work with
+        category = Category.objects.create(
+            # maybe issues with label /  request.user
+            label=label
+        )
+
+        serializer = CategorySerializer(category, context={"request": request})
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    def update(self, request, pk=None):
+        try:
+            category = Category.objects.get(pk=pk)
+
+            # Is the authenticated user allowed to edit this category?
+            self.check_object_permissions(request, category)
+
+            serializer = CategorySerializer(data=request.data)
+            if serializer.is_valid():
+                category.label = serializer.validated_data["label"]
+                # category.created_on = serializer.validated_data["created_on"]
+                category.save()
+
+                serializer = CategorySerializer(category, context={"request": request})
+                return Response(None, status.HTTP_204_NO_CONTENT)
+
+            return Response(serializer.errors, status.HTTP_400_BAD_REQUEST)
+
+        except Category.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+    def destroy(self, request, pk=None):
+        try:
+            category = Category.objects.get(pk=pk)
+            self.check_object_permissions(request, category)
+            category.delete()
+
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
         except Category.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)

--- a/rareapi/views/tags.py
+++ b/rareapi/views/tags.py
@@ -3,14 +3,14 @@ from rest_framework import serializers
 from rest_framework.response import Response
 from rareapi.models import Tag
 
+
 class TagSerializer(serializers.ModelSerializer):
     class Meta:
         model = Tag
-        fields = ['id', 'label']
+        fields = ["id", "label"]
 
 
 class TagViewSet(viewsets.ViewSet):
-
     def list(self, request):
         tags = Tag.objects.all()
         serializer = TagSerializer(tags, many=True)
@@ -21,5 +21,51 @@ class TagViewSet(viewsets.ViewSet):
             tag = Tag.objects.get(pk=pk)
             serializer = TagSerializer(tag)
             return Response(serializer.data)
+        except Tag.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+    def create(self, request):
+        # Get the data from the client's JSON payload
+        label = request.data.get("label")
+
+        # Create a comment database row first, so you have a
+        # primary key to work with
+        tag = Tag.objects.create(
+            # maybe issues with label /  request.user
+            label=label
+        )
+
+        serializer = TagSerializer(tag, context={"request": request})
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    def update(self, request, pk=None):
+        try:
+            tag = Tag.objects.get(pk=pk)
+
+            # Is the authenticated user allowed to edit this tag?
+            self.check_object_permissions(request, tag)
+
+            serializer = TagSerializer(data=request.data)
+            if serializer.is_valid():
+                tag.label = serializer.validated_data["label"]
+                # tag.created_on = serializer.validated_data["created_on"]
+                tag.save()
+
+                serializer = TagSerializer(tag, context={"request": request})
+                return Response(None, status.HTTP_204_NO_CONTENT)
+
+            return Response(serializer.errors, status.HTTP_400_BAD_REQUEST)
+
+        except Tag.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+    def destroy(self, request, pk=None):
+        try:
+            tag = Tag.objects.get(pk=pk)
+            self.check_object_permissions(request, tag)
+            tag.delete()
+
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
         except Tag.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
# Categories and Tags can now be queried from the database via GET, Put, Post and Delete
**New Supported Routes**
1. `/tags`
3. `/categories`

## STEPS TO TEST

1. Pull down the `jafgo6` branch and switch to it
2. Start/Restart your debugger/JSON-Server
3. Open Postman
4. Request `http://localhost:8000/tags or http://localhost:8000/categories` and verify you see all existing comments. Each comment should include
- a unique primary key
- a varchar called label
5. Verify response code of 201
6. Post tags or categories with Post 
7. Edit tags or categories with Put 
8. Delete tags or categories with Delete
