### PR TITLE
Added created_on to fields in CommentSerializer

### DIFF
--- a/rareapi/views/comments.py
+++ b/rareapi/views/comments.py
@@ -5,8 +5,8 @@ from rareapi.models import Comment, RareUser, Post
 from .users import RareUserSerializer
 from .posts import PostSerializer
 
-class SimpleCommentSerializer(serializers.ModelSerializer):
 
+class SimpleCommentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Comment
         fields = [
@@ -14,6 +14,7 @@ class SimpleCommentSerializer(serializers.ModelSerializer):
             "author",
             "content",
         ]
+
 
 class CommentSerializer(serializers.ModelSerializer):
     # !Unsure of which user serializer to use. Don't forget to import UserSerializer from .users
@@ -35,6 +36,7 @@ class CommentSerializer(serializers.ModelSerializer):
             "author",
             "content",
             "is_owner",
+            "created_on",
         ]
         # read_only_field = ["user"]
 


### PR DESCRIPTION
#Comments should now have a created_on field.

## STEPS TO TEST

1. Pull down the `jafgo7` branch and switch to it
2. Start/Restart your debugger/JSON-Server
3. Open Postman
4. Request `http://localhost:8000/comments` and verify you see a created_on field for each comment. 
5. Verify response code of 201